### PR TITLE
Rolling Appender

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,20 @@ function is passed a `log_Event` structure containing the `line` number,
 `filename`, `fmt` string, `va` printf va\_list, `level` and the given `udata`.
 
 
+#### log_add_rolling_appender(rolling_appender ra, int level)
+One or more rolling log appenders. This is functionally equivalent to
+`log_add_fp()` from a logging standpoint. The function also handles log _file_
+management based on the values provided by the `rolling_appender` struct
+argument.
+
+After a log entry pushes the log size over the `ra.max_log_size` value, your
+active log is automatically rolled.
+
+Rolled logs appear in the same directory as the active log, and retain the same
+name as the active log, except a numeric value from `1` to `ra.max_logs`
+is appended to the end of the file name.
+
+
 #### log_set_lock(log_LockFn fn, void *udata)
 If the log will be written to from multiple threads a lock function can be set.
 The function is passed the boolean `true` if the lock should be acquired or

--- a/src/log.h
+++ b/src/log.h
@@ -8,12 +8,28 @@
 #ifndef LOG_H
 #define LOG_H
 
-#include <stdio.h>
-#include <stdarg.h>
-#include <stdbool.h>
-#include <time.h>
+#ifdef __cplusplus
+extern "C"
+{
+#endif
 
-#define LOG_VERSION "0.1.0"
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <time.h>
+#include <unistd.h>
+
+#define LOG_VERSION "0.2.0"
+
+typedef struct {
+  char* file_name;
+  off_t max_log_size;
+  unsigned int max_logs;
+} rolling_appender;
 
 typedef struct {
   va_list ap;
@@ -23,6 +39,7 @@ typedef struct {
   void *udata;
   int line;
   int level;
+  rolling_appender ra;
 } log_Event;
 
 typedef void (*log_LogFn)(log_Event *ev);
@@ -42,8 +59,13 @@ void log_set_lock(log_LockFn fn, void *udata);
 void log_set_level(int level);
 void log_set_quiet(bool enable);
 int log_add_callback(log_LogFn fn, void *udata, int level);
+int log_add_rolling_appender(rolling_appender ra, int level);
 int log_add_fp(FILE *fp, int level);
 
 void log_log(int level, const char *file, int line, const char *fmt, ...);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
Added a rolling appender function for basic log file management.

Most applications that are concerned with this behavior should consider sending
messages to syslog and use traditional logrotate mechanisms to manage log
files. However, there is a niche of applications that could benefit from this
feature in a compact logging library.