### PR TITLE
add fullpath option for write file's path

### DIFF
--- a/example/demo.c
+++ b/example/demo.c
@@ -1,0 +1,61 @@
+#include "../src/log.h"
+#include <pthread.h>
+#include <signal.h>
+
+bool s_stop = false;
+pthread_mutex_t MUTEX_LOG;
+void log_lock(bool lock, void *udata);
+
+void log_lock(bool lock, void* udata) {
+    pthread_mutex_t *LOCK = (pthread_mutex_t*)(udata);
+    if (lock)
+        pthread_mutex_lock(LOCK);
+    else
+        pthread_mutex_unlock(LOCK);
+}
+
+void run(void *arg) {
+    int id = *(int*)arg;
+    log_debug("+++++id: %d", id);
+    unsigned int idx = 0;
+    for (;;) {
+    	log_debug("thread id: %d idx:%u", id, idx++);
+	    usleep(1000 * 100);
+	    if (s_stop) break;
+    }
+}
+
+void stop(int signo) {
+    (void)signo;
+    s_stop = true;
+}
+
+int main() {
+    pthread_mutex_init(&MUTEX_LOG, NULL);
+    log_set_lock(log_lock, &MUTEX_LOG);
+
+    FILE* fp = fopen ("demo.log", "a+");
+    log_set_quiet(true);
+    log_set_level(LOG_DEBUG);
+    log_set_fullpath(false);
+    log_add_fp(fp, LOG_DEBUG);
+
+    signal(SIGINT, stop);
+    signal(SIGKILL, stop); 
+    signal(SIGTERM, stop);
+
+    pthread_t h[8];
+    int id_array[8] = {0,1,2,3,4,5,6,7};
+    for (int i= 0; i<8; i++) {
+        pthread_create(&h[i], NULL, run, &id_array[i]);
+    }
+
+    void* ret[8] = {NULL};
+    for (int i=0; i<8; i++) {
+        pthread_join(h[i], &ret);
+    }
+
+    pthread_mutex_destroy(&MUTEX_LOG);
+
+    fclose(fp);
+}

--- a/src/log.c
+++ b/src/log.c
@@ -21,6 +21,7 @@
  */
 
 #include "log.h"
+#include <libgen.h>
 
 #define MAX_CALLBACKS 32
 
@@ -35,6 +36,7 @@ static struct {
   log_LockFn lock;
   int level;
   bool quiet;
+  bool fullpath;
   Callback callbacks[MAX_CALLBACKS];
 } L;
 
@@ -111,6 +113,9 @@ void log_set_quiet(bool enable) {
   L.quiet = enable;
 }
 
+void log_set_fullpath(bool enable) {
+  L.fullpath = enable;
+}
 
 int log_add_callback(log_LogFn fn, void *udata, int level) {
   for (int i = 0; i < MAX_CALLBACKS; i++) {
@@ -140,7 +145,7 @@ static void init_event(log_Event *ev, void *udata) {
 void log_log(int level, const char *file, int line, const char *fmt, ...) {
   log_Event ev = {
     .fmt   = fmt,
-    .file  = file,
+    .file  = L.fullpath ? file : basename((char*)file),
     .line  = line,
     .level = level,
   };

--- a/src/log.h
+++ b/src/log.h
@@ -41,6 +41,7 @@ const char* log_level_string(int level);
 void log_set_lock(log_LockFn fn, void *udata);
 void log_set_level(int level);
 void log_set_quiet(bool enable);
+void log_set_fullpath(bool enable);
 int log_add_callback(log_LogFn fn, void *udata, int level);
 int log_add_fp(FILE *fp, int level);
 


### PR DESCRIPTION
when using log.c to dump information, the __FILE__will be very long if the .c file's path is deep. So i add a option to enable/disable writing the file's full path.