### PR TITLE
Modify function from localtime to localtime_r

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -52,7 +52,7 @@ static const char *level_colors[] = {
 
 static void stdout_callback(log_Event *ev) {
   char buf[16];
-  buf[strftime(buf, sizeof(buf), "%H:%M:%S", ev->time)] = '\0';
+  buf[strftime(buf, sizeof(buf), "%H:%M:%S", &ev->time)] = '\0';
 #ifdef LOG_USE_COLOR
   fprintf(
     ev->udata, "%s %s%-5s\x1b[0m \x1b[90m%s:%d:\x1b[0m ",
@@ -71,7 +71,7 @@ static void stdout_callback(log_Event *ev) {
 
 static void file_callback(log_Event *ev) {
   char buf[64];
-  buf[strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", ev->time)] = '\0';
+  buf[strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", &ev->time)] = '\0';
   fprintf(
     ev->udata, "%s %-5s %s:%d: ",
     buf, level_strings[ev->level], ev->file, ev->line);
@@ -129,9 +129,9 @@ int log_add_fp(FILE *fp, int level) {
 
 
 static void init_event(log_Event *ev, void *udata) {
-  if (!ev->time) {
+  if (!(&ev->time)) {
     time_t t = time(NULL);
-    ev->time = localtime(&t);
+    localtime_r(&t, &ev->time);
   }
   ev->udata = udata;
 }

--- a/src/log.h
+++ b/src/log.h
@@ -19,7 +19,7 @@ typedef struct {
   va_list ap;
   const char *fmt;
   const char *file;
-  struct tm *time;
+  struct tm time;
   void *udata;
   int line;
   int level;


### PR DESCRIPTION
Sometimes user want to display log which about time, but in following example, it will get wrong time, because localtime doc says: 
> The returned value points to an internal object whose validity or value may be altered by any subsequent call to gmtime or localtime."  

, maybe change function to localtime_r is a good way.

In this example, it will get the current time, but I hope it's getting `2021/01/01 00:00:00`  

```c
#include <stdio.h>
#include <stdlib.h>
#include <time.h>

#include "log/src/log.h"

#define DATETIME_BUF_SIZE 0xff
#define DATETIME_FORMAT "%Y/%m/%d %H:%M:%S"

int get_datetime(time_t timestamp, char* datetime) {
  struct tm *local;

  local = localtime(&timestamp);
  log_info("Current sec: %d", local->tm_sec);
  log_info("Current min: %d", local->tm_min);
  log_info("Current hour: %d", local->tm_hour);
  log_info("Current mday: %d", local->tm_mday);
  log_info("Current mon: %d", local->tm_mon + 1);
  log_info("Current year: %d", local->tm_year + 1900);
  log_info("Current wday: %d", local->tm_wday);
  log_info("Current yday: %d", local->tm_yday);

  strftime(datetime, DATETIME_BUF_SIZE, DATETIME_FORMAT, local);
  return 0;
}

int main() {
  time_t timestamp = 1609430400; // 2021/01/01 00:00:00
  char datetime[DATETIME_BUF_SIZE];

  get_datetime(timestamp, datetime);
  log_info("Display datetime: %s\n", datetime);
  return 0;
}
```