### PR TITLE
Add log_set_stderr_level() that enables switching between stdout and stderr

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -34,6 +34,7 @@ static struct {
   void *udata;
   log_LockFn lock;
   int level;
+  int level_stderr;
   bool quiet;
   Callback callbacks[MAX_CALLBACKS];
 } L;
@@ -106,6 +107,9 @@ void log_set_level(int level) {
   L.level = level;
 }
 
+void log_set_level_stderr(int level) {
+  L.level_stderr = level;
+}
 
 void log_set_quiet(bool enable) {
   L.quiet = enable;
@@ -148,7 +152,7 @@ void log_log(int level, const char *file, int line, const char *fmt, ...) {
   lock();
 
   if (!L.quiet && level >= L.level) {
-    init_event(&ev, stderr);
+    init_event(&ev, level >= L.level_stderr ? stderr : stdout);
     va_start(ev.ap, fmt);
     stdout_callback(&ev);
     va_end(ev.ap);

--- a/src/log.h
+++ b/src/log.h
@@ -40,6 +40,7 @@ enum { LOG_TRACE, LOG_DEBUG, LOG_INFO, LOG_WARN, LOG_ERROR, LOG_FATAL };
 const char* log_level_string(int level);
 void log_set_lock(log_LockFn fn, void *udata);
 void log_set_level(int level);
+void log_set_level_stderr(int level);
 void log_set_quiet(bool enable);
 int log_add_callback(log_LogFn fn, void *udata, int level);
 int log_add_fp(FILE *fp, int level);


### PR DESCRIPTION
This new level flag allows to log to either stderr or stdout considering the log level.

By default the value is 0 so everything goes to stderr.
If you set it to max, everything goes to stdout.
If you set `log_set_level(LOG_INFO); log_set_stderr_level(LOG_ERROR);`, INFO and WARN goes to stdout and ERROR, FATAL goes to stderr.