### PR TITLE
set log level of registered callbacks

### DIFF
--- a/src/example/example.c
+++ b/src/example/example.c
@@ -1,0 +1,53 @@
+#include <stdio.h>
+#include "../log.h"
+
+extern const char *level_strings[];
+
+void callback1(log_Event *ev)
+{
+    char logline[128];
+    snprintf(logline, 128, "%-5s %s:%d: ",
+        level_strings[ev->level], ev->file, ev->line);
+    vsnprintf(logline, 128, ev->fmt, ev->ap);
+    printf("%s: %s\n", __func__, logline);
+}
+
+void callback2(log_Event *ev)
+{
+    char logline[128];
+    snprintf(logline, 128, "%-5s %s:%d: ",
+        level_strings[ev->level], ev->file, ev->line);
+    vsnprintf(logline, 128, ev->fmt, ev->ap);
+    printf("%s: %s\n", __func__, logline);
+}
+
+int main()
+{
+    log_trace("hello");
+    log_debug("hello");
+    log_info("hello");
+    log_warn("hello");
+    log_error("hello");
+    log_fatal("hello");
+    log_debug("============== update loglevel to FATAL =============");
+    log_set_level(LOG_FATAL);
+    log_trace("hello");
+    log_debug("hello");
+    log_info("hello");
+    log_warn("hello");
+    log_error("hello");
+    log_fatal("hello");
+    log_debug("===================== init log =====================");
+    log_add_callback(callback1, "progname", LOG_TRACE);
+    log_add_callback(callback2, "progname", LOG_TRACE);
+    log_trace("hello");
+    log_debug("hello");
+    log_info("hello");
+    log_warn("hello");
+    log_error("hello");
+    log_fatal("hello");
+    log_debug("============ update loglevels of callbacks ========");
+    log_set_level_callback(callback1, LOG_FATAL);
+    log_set_level_callback(callback2, LOG_WARN);
+    return 0;
+}

--- a/src/example/example.c
+++ b/src/example/example.c
@@ -5,20 +5,22 @@ extern const char *level_strings[];
 
 void callback1(log_Event *ev)
 {
-    char logline[128];
-    snprintf(logline, 128, "%-5s %s:%d: ",
-        level_strings[ev->level], ev->file, ev->line);
-    vsnprintf(logline, 128, ev->fmt, ev->ap);
-    printf("%s: %s\n", __func__, logline);
+    char buf[16];
+    buf[strftime(buf, sizeof(buf), "%H:%M:%S", ev->time)] = '\0';
+    fprintf(stdout, "callback 1 %s %-5s %s:%d: ", buf, level_strings[ev->level], ev->file, ev->line);
+    vfprintf(stdout, ev->fmt, ev->ap);
+    fprintf(stdout, "\n");
+    fflush(stdout);
 }
 
 void callback2(log_Event *ev)
 {
-    char logline[128];
-    snprintf(logline, 128, "%-5s %s:%d: ",
-        level_strings[ev->level], ev->file, ev->line);
-    vsnprintf(logline, 128, ev->fmt, ev->ap);
-    printf("%s: %s\n", __func__, logline);
+    char buf[16];
+    buf[strftime(buf, sizeof(buf), "%H:%M:%S", ev->time)] = '\0';
+    fprintf(stdout, "callback 2 %s %-5s %s:%d: ", buf, level_strings[ev->level], ev->file, ev->line);
+    vfprintf(stdout, ev->fmt, ev->ap);
+    fprintf(stdout, "\n");
+    fflush(stdout);
 }
 
 int main()
@@ -29,7 +31,7 @@ int main()
     log_warn("hello");
     log_error("hello");
     log_fatal("hello");
-    log_debug("============== update loglevel to FATAL =============");
+    printf("============== update loglevel to FATAL =============\n");
     log_set_level(LOG_FATAL);
     log_trace("hello");
     log_debug("hello");
@@ -37,7 +39,7 @@ int main()
     log_warn("hello");
     log_error("hello");
     log_fatal("hello");
-    log_debug("===================== init log =====================");
+    printf("===================== add callback =================\n");
     log_add_callback(callback1, "progname", LOG_TRACE);
     log_add_callback(callback2, "progname", LOG_TRACE);
     log_trace("hello");
@@ -46,8 +48,14 @@ int main()
     log_warn("hello");
     log_error("hello");
     log_fatal("hello");
-    log_debug("============ update loglevels of callbacks ========");
+    printf("============ update loglevels of callbacks ========\n");
     log_set_level_callback(callback1, LOG_FATAL);
     log_set_level_callback(callback2, LOG_WARN);
+    log_trace("hello");
+    log_debug("hello");
+    log_info("hello");
+    log_warn("hello");
+    log_error("hello");
+    log_fatal("hello");
     return 0;
 }

--- a/src/log.c
+++ b/src/log.c
@@ -39,7 +39,7 @@ static struct {
 } L;
 
 
-static const char *level_strings[] = {
+const char *level_strings[] = {
   "TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL"
 };
 
@@ -121,6 +121,17 @@ int log_add_callback(log_LogFn fn, void *udata, int level) {
   }
   return -1;
 }
+
+int log_set_level_callback(log_LogFn fn, int level) {
+  for (int i = 0; i < MAX_CALLBACKS; i++) {
+    if (L.callbacks[i].fn == fn) {
+      L.callbacks[i].level = level;
+      return 0;
+    }
+  }
+  return -1;
+}
+
 
 
 int log_add_fp(FILE *fp, int level) {

--- a/src/log.h
+++ b/src/log.h
@@ -42,6 +42,7 @@ void log_set_lock(log_LockFn fn, void *udata);
 void log_set_level(int level);
 void log_set_quiet(bool enable);
 int log_add_callback(log_LogFn fn, void *udata, int level);
+int log_set_level_callback(log_LogFn fn, int level);
 int log_add_fp(FILE *fp, int level);
 
 void log_log(int level, const char *file, int line, const char *fmt, ...);


### PR DESCRIPTION
There was only one way to add log level to a logger callback function, and I added a function that sets a new log level for a callback. I wanted it to be changed at run time, ie. after callback had been added.

See the example/example.c file that I added.