### PR TITLE
Disable reporting of log source at compile time

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Each function takes a printf format string followed by additional arguments:
 log_trace("Hello %s", "world")
 ```
 
-Resulting in a line with the given format printed to stderr:
+Resulting in a line with a format like the following being printed to stderr:
 
 ```
 20:18:26 TRACE src/main.c:11: Hello world
@@ -46,7 +46,7 @@ level is `LOG_TRACE`, such that nothing is ignored.
 #### log_add_fp(FILE *fp, int level)
 One or more file pointers where the log will be written can be provided to the
 library by using the `log_add_fp()` function. The data written to the file
-output is of the following format:
+output is of a format like the following:
 
 ```
 2047-03-11 20:18:26 TRACE src/main.c:11: Hello world
@@ -76,6 +76,11 @@ Returns the name of the given log level as a string.
 #### LOG_USE_COLOR
 If the library is compiled with `-DLOG_USE_COLOR` ANSI color escape codes will
 be used when printing.
+
+
+#### LOG_SOURCE
+If the library is compiled with `-DLOG_SOURCE`, the file name and line number on
+which log messages occurred will be printed.
 
 
 ## License

--- a/src/log.c
+++ b/src/log.c
@@ -54,15 +54,32 @@ static void stdout_callback(log_Event *ev) {
   char buf[16];
   buf[strftime(buf, sizeof(buf), "%H:%M:%S", ev->time)] = '\0';
 #ifdef LOG_USE_COLOR
+
+#ifdef LOG_SOURCE
   fprintf(
     ev->udata, "%s %s%-5s\x1b[0m \x1b[90m%s:%d:\x1b[0m ",
     buf, level_colors[ev->level], level_strings[ev->level],
     ev->file, ev->line);
 #else
   fprintf(
+    ev->udata, "%s %s%-5s\x1b[0m: ",
+    buf, level_colors[ev->level], level_strings[ev->level]);
+#endif /* LOG_SOURCE */
+
+#else /* LOG_USE_COLOR */
+
+#ifdef LOG_SOURCE
+  fprintf(
     ev->udata, "%s %-5s %s:%d: ",
     buf, level_strings[ev->level], ev->file, ev->line);
-#endif
+#else
+  fprintf(
+    ev->udata, "%s %-5s: ",
+    buf, level_strings[ev->level]);
+#endif /* LOG_SOURCE */
+
+#endif /* LOG_USE_COLOR */
+
   vfprintf(ev->udata, ev->fmt, ev->ap);
   fprintf(ev->udata, "\n");
   fflush(ev->udata);
@@ -72,9 +89,17 @@ static void stdout_callback(log_Event *ev) {
 static void file_callback(log_Event *ev) {
   char buf[64];
   buf[strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", ev->time)] = '\0';
+
+#ifdef LOG_SOURCE
   fprintf(
     ev->udata, "%s %-5s %s:%d: ",
     buf, level_strings[ev->level], ev->file, ev->line);
+#else
+  fprintf(
+    ev->udata, "%s %-5s: ",
+    buf, level_strings[ev->level]);
+#endif
+
   vfprintf(ev->udata, ev->fmt, ev->ap);
   fprintf(ev->udata, "\n");
   fflush(ev->udata);
@@ -137,6 +162,28 @@ static void init_event(log_Event *ev, void *udata) {
 }
 
 
+static void log_event(log_Event *ev) {
+  lock();
+
+  if (!L.quiet && ev->level >= L.level) {
+    init_event(ev, stderr);
+    stdout_callback(ev);
+  }
+
+  for (int i = 0; i < MAX_CALLBACKS && L.callbacks[i].fn; i++) {
+    Callback *cb = &L.callbacks[i];
+    if (ev->level >= cb->level) {
+      init_event(ev, cb->udata);
+      cb->fn(ev);
+    }
+  }
+
+  unlock();
+}
+
+
+#ifdef LOG_SOURCE
+
 void log_log(int level, const char *file, int line, const char *fmt, ...) {
   log_Event ev = {
     .fmt   = fmt,
@@ -144,25 +191,21 @@ void log_log(int level, const char *file, int line, const char *fmt, ...) {
     .line  = line,
     .level = level,
   };
-
-  lock();
-
-  if (!L.quiet && level >= L.level) {
-    init_event(&ev, stderr);
-    va_start(ev.ap, fmt);
-    stdout_callback(&ev);
-    va_end(ev.ap);
-  }
-
-  for (int i = 0; i < MAX_CALLBACKS && L.callbacks[i].fn; i++) {
-    Callback *cb = &L.callbacks[i];
-    if (level >= cb->level) {
-      init_event(&ev, cb->udata);
-      va_start(ev.ap, fmt);
-      cb->fn(&ev);
-      va_end(ev.ap);
-    }
-  }
-
-  unlock();
+  va_start(ev.ap, fmt);
+  log_event(&ev);
+  va_end(ev.ap);
 }
+
+#else
+
+void log_log(int level, const char *fmt, ...) {
+  log_Event ev = {
+    .fmt   = fmt,
+    .level = level,
+  };
+  va_start(ev.ap, fmt);
+  log_event(&ev);
+  va_end(ev.ap);
+}
+
+#endif /* LOG_SOURCE */

--- a/src/log.h
+++ b/src/log.h
@@ -18,10 +18,14 @@
 typedef struct {
   va_list ap;
   const char *fmt;
+#ifdef LOG_SOURCE
   const char *file;
+#endif
   struct tm *time;
   void *udata;
+#ifdef LOG_SOURCE
   int line;
+#endif
   int level;
 } log_Event;
 
@@ -30,12 +34,25 @@ typedef void (*log_LockFn)(bool lock, void *udata);
 
 enum { LOG_TRACE, LOG_DEBUG, LOG_INFO, LOG_WARN, LOG_ERROR, LOG_FATAL };
 
+#ifdef LOG_SOURCE
+
 #define log_trace(...) log_log(LOG_TRACE, __FILE__, __LINE__, __VA_ARGS__)
 #define log_debug(...) log_log(LOG_DEBUG, __FILE__, __LINE__, __VA_ARGS__)
 #define log_info(...)  log_log(LOG_INFO,  __FILE__, __LINE__, __VA_ARGS__)
 #define log_warn(...)  log_log(LOG_WARN,  __FILE__, __LINE__, __VA_ARGS__)
 #define log_error(...) log_log(LOG_ERROR, __FILE__, __LINE__, __VA_ARGS__)
 #define log_fatal(...) log_log(LOG_FATAL, __FILE__, __LINE__, __VA_ARGS__)
+
+#else
+
+#define log_trace(...) log_log(LOG_TRACE, __VA_ARGS__)
+#define log_debug(...) log_log(LOG_DEBUG, __VA_ARGS__)
+#define log_info(...)  log_log(LOG_INFO, __VA_ARGS__)
+#define log_warn(...)  log_log(LOG_WARN, __VA_ARGS__)
+#define log_error(...) log_log(LOG_ERROR, __VA_ARGS__)
+#define log_fatal(...) log_log(LOG_FATAL, __VA_ARGS__)
+
+#endif /* LOG_SOURCE */
 
 const char* log_level_string(int level);
 void log_set_lock(log_LockFn fn, void *udata);
@@ -44,6 +61,10 @@ void log_set_quiet(bool enable);
 int log_add_callback(log_LogFn fn, void *udata, int level);
 int log_add_fp(FILE *fp, int level);
 
+#ifdef LOG_SOURCE
 void log_log(int level, const char *file, int line, const char *fmt, ...);
+#else
+void log_log(int level, const char *fmt, ...);
+#endif
 
 #endif


### PR DESCRIPTION
By default, disable the reporting of the file name and line number on which `log_log` (and its convenience macros) are called. Only output this information if the `LOG_SOURCE` macro is defined.