### PR TITLE
fix: stringify __LINE__ macro to avoid overflow

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -55,12 +55,12 @@ static void stdout_callback(log_Event *ev) {
   buf[strftime(buf, sizeof(buf), "%H:%M:%S", ev->time)] = '\0';
 #ifdef LOG_USE_COLOR
   fprintf(
-    ev->udata, "%s %s%-5s\x1b[0m \x1b[90m%s:%d:\x1b[0m ",
+    ev->udata, "%s %s%-5s\x1b[0m \x1b[90m%s:%s:\x1b[0m ",
     buf, level_colors[ev->level], level_strings[ev->level],
     ev->file, ev->line);
 #else
   fprintf(
-    ev->udata, "%s %-5s %s:%d: ",
+    ev->udata, "%s %-5s %s:%s: ",
     buf, level_strings[ev->level], ev->file, ev->line);
 #endif
   vfprintf(ev->udata, ev->fmt, ev->ap);
@@ -73,7 +73,7 @@ static void file_callback(log_Event *ev) {
   char buf[64];
   buf[strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", ev->time)] = '\0';
   fprintf(
-    ev->udata, "%s %-5s %s:%d: ",
+    ev->udata, "%s %-5s %s:%s: ",
     buf, level_strings[ev->level], ev->file, ev->line);
   vfprintf(ev->udata, ev->fmt, ev->ap);
   fprintf(ev->udata, "\n");
@@ -137,7 +137,7 @@ static void init_event(log_Event *ev, void *udata) {
 }
 
 
-void log_log(int level, const char *file, int line, const char *fmt, ...) {
+void log_log(int level, const char *file, const char *line, const char *fmt, ...) {
   log_Event ev = {
     .fmt   = fmt,
     .file  = file,

--- a/src/log.h
+++ b/src/log.h
@@ -21,7 +21,7 @@ typedef struct {
   const char *file;
   struct tm *time;
   void *udata;
-  int line;
+  const char *line;
   int level;
 } log_Event;
 
@@ -30,12 +30,15 @@ typedef void (*log_LockFn)(bool lock, void *udata);
 
 enum { LOG_TRACE, LOG_DEBUG, LOG_INFO, LOG_WARN, LOG_ERROR, LOG_FATAL };
 
-#define log_trace(...) log_log(LOG_TRACE, __FILE__, __LINE__, __VA_ARGS__)
-#define log_debug(...) log_log(LOG_DEBUG, __FILE__, __LINE__, __VA_ARGS__)
-#define log_info(...)  log_log(LOG_INFO,  __FILE__, __LINE__, __VA_ARGS__)
-#define log_warn(...)  log_log(LOG_WARN,  __FILE__, __LINE__, __VA_ARGS__)
-#define log_error(...) log_log(LOG_ERROR, __FILE__, __LINE__, __VA_ARGS__)
-#define log_fatal(...) log_log(LOG_FATAL, __FILE__, __LINE__, __VA_ARGS__)
+#define _STRINGIFY(X) #X
+#define STRINGIFY(X) _STRINGIFY(X)
+
+#define log_trace(...) log_log(LOG_TRACE, __FILE__, "" STRINGIFY(__LINE__), __VA_ARGS__)
+#define log_debug(...) log_log(LOG_DEBUG, __FILE__, "" STRINGIFY(__LINE__), __VA_ARGS__)
+#define log_info(...)  log_log(LOG_INFO,  __FILE__, "" STRINGIFY(__LINE__), __VA_ARGS__)
+#define log_warn(...)  log_log(LOG_WARN,  __FILE__, "" STRINGIFY(__LINE__), __VA_ARGS__)
+#define log_error(...) log_log(LOG_ERROR, __FILE__, "" STRINGIFY(__LINE__), __VA_ARGS__)
+#define log_fatal(...) log_log(LOG_FATAL, __FILE__, "" STRINGIFY(__LINE__), __VA_ARGS__)
 
 const char* log_level_string(int level);
 void log_set_lock(log_LockFn fn, void *udata);
@@ -44,6 +47,6 @@ void log_set_quiet(bool enable);
 int log_add_callback(log_LogFn fn, void *udata, int level);
 int log_add_fp(FILE *fp, int level);
 
-void log_log(int level, const char *file, int line, const char *fmt, ...);
+void log_log(int level, const char *file, const char *line, const char *fmt, ...);
 
 #endif

--- a/src/log.h
+++ b/src/log.h
@@ -30,15 +30,21 @@ typedef void (*log_LockFn)(bool lock, void *udata);
 
 enum { LOG_TRACE, LOG_DEBUG, LOG_INFO, LOG_WARN, LOG_ERROR, LOG_FATAL };
 
-#define _STRINGIFY(X) #X
-#define STRINGIFY(X) _STRINGIFY(X)
+#define _LOG_STRINGIFY(X) #X
+#define LOG_STRINGIFY(X) _LOG_STRINGIFY(X)
 
-#define log_trace(...) log_log(LOG_TRACE, __FILE__, "" STRINGIFY(__LINE__), __VA_ARGS__)
-#define log_debug(...) log_log(LOG_DEBUG, __FILE__, "" STRINGIFY(__LINE__), __VA_ARGS__)
-#define log_info(...)  log_log(LOG_INFO,  __FILE__, "" STRINGIFY(__LINE__), __VA_ARGS__)
-#define log_warn(...)  log_log(LOG_WARN,  __FILE__, "" STRINGIFY(__LINE__), __VA_ARGS__)
-#define log_error(...) log_log(LOG_ERROR, __FILE__, "" STRINGIFY(__LINE__), __VA_ARGS__)
-#define log_fatal(...) log_log(LOG_FATAL, __FILE__, "" STRINGIFY(__LINE__), __VA_ARGS__)
+#define log_trace(...) \
+  log_log(LOG_TRACE, __FILE__, "" LOG_STRINGIFY(__LINE__), __VA_ARGS__)
+#define log_debug(...) \
+  log_log(LOG_DEBUG, __FILE__, "" LOG_STRINGIFY(__LINE__), __VA_ARGS__)
+#define log_info(...)  \
+  log_log(LOG_INFO, __FILE__, "" LOG_STRINGIFY(__LINE__), __VA_ARGS__)
+#define log_warn(...)  \
+  log_log(LOG_WARN, __FILE__, "" LOG_STRINGIFY(__LINE__), __VA_ARGS__)
+#define log_error(...) \
+  log_log(LOG_ERROR, __FILE__, "" LOG_STRINGIFY(__LINE__), __VA_ARGS__)
+#define log_fatal(...) \
+  log_log(LOG_FATAL, __FILE__, "" LOG_STRINGIFY(__LINE__), __VA_ARGS__)
 
 const char* log_level_string(int level);
 void log_set_lock(log_LockFn fn, void *udata);


### PR DESCRIPTION
Currently, the expansion for the `__LINE__` macro is type `int` which may be uncomfortably small on 32-bit machines or other platforms where `int ` is smaller.

The work around is a bit silly (as macros are), however, less dangerous than a potentially uncaught integer overflow in large source files. 

A good middle ground might just to be making `line` a `long`, although this again technically has the possibility of overflowing on rather large files.